### PR TITLE
fix: detect bibliography entries via [N] text in typst >= 0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 Cargo.lock
 .DS_Store
+*.pdf

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -74,69 +74,41 @@
       bytes(keys.join(",")),
     )).split()
 
-    // Grid-based styles, such as IEEE.
-    show grid: it => {
-      if not it.has("label") {
-        // Modify every second child which represents the entry itself.
-        let modified-children = it
-          .children
-          .enumerate()
-          .map(((i, c)) => {
-            if calc.odd(i) {
-              _bib-counter.step()
-              (
-                c
-                  + " "
-                  + context {
-                    let idx = _bib-counter.get().first() - 1
-                    _cited-pages(format, label(sorted-keys.at(idx)))
-                  }
-              )
-            } else {
-              c
-            }
-          })
+    // Track the highest-numbered entry seen so we can append a trailing
+    // backref for the last entry (which has no following [N+1] to anchor on).
+    let _last-n = state("retrofit-last-n", 0)
 
-        let fields = it.fields()
-        let _ = fields.remove("children")
-
-        [#grid(..fields, ..modified-children)<grid>]
-      } else {
-        it
-      }
-    }
-
-    // Provide bibliography heading body via metadata.
-    show heading: it => [#it#metadata(it.body)<bib-heading>]
-    // Non-grid based styles (blocks with v-spacing), such as APA.
-    show block: it => {
-      if it.body == auto { return it }
-      if not it.has("label") {
-        // If we detected the bibliography heading, skip styling.
-        if query(<bib-heading>).first().value == it.body {
-          return it
-        }
-
-        _bib-counter.step()
-        let modified-body = (
-          it.body
-            + " "
-            + context {
-              let idx = _bib-counter.get().first() - 1
-              _cited-pages(format, label(sorted-keys.at(idx)))
-            }
-        )
-
-        let fields = it.fields()
-        let _ = fields.remove("body")
-
-        [#block(..fields, modified-body)<block>]
+    // Numbered styles (IEEE, GB-7714, etc.): in typst >= 0.14 each entry
+    // is no longer wrapped in its own grid row or block — bibliography
+    // renders as one block of flowing text. But every entry still begins
+    // with a standalone text element matching the literal pattern `[N]`,
+    // which we use as the entry boundary anchor.
+    //
+    // Strategy: when we see `[N]` for N >= 2, prepend the backref for
+    // entry N-1 (which sits immediately before this label in the flow).
+    // For the final entry, append after `bib` renders. A zero-width-space
+    // sentinel marks already-processed text to prevent show-rule recursion.
+    show text: it => {
+      let m = it.text.match(regex("^\[(\d+)\]$"))
+      if m == none { return it }
+      let n = int(m.captures.first())
+      _last-n.update(prev => calc.max(prev, n))
+      if n >= 2 and n - 1 <= sorted-keys.len() {
+        _cited-pages(format, label(sorted-keys.at(n - 2))) + it
       } else {
         it
       }
     }
 
     bib
+
+    // Append backref for the last numbered entry.
+    context {
+      let n = _last-n.get()
+      if n >= 1 and n <= sorted-keys.len() {
+        _cited-pages(format, label(sorted-keys.at(n - 1)))
+      }
+    }
   }
 
   doc


### PR DESCRIPTION
## Problem

retrofit 0.1.2 produces no backreferences when compiled with typst 0.14+. In typst 0.14 the bibliography element changed: it no longer wraps each entry in its own grid row or block — the whole reference list renders as one flowing block of text. retrofit's existing `show grid:` and `show block:` rules never match, so the `format` callback is never invoked.

Reproducible with retrofit's own `tests/ieee.typ` on typst 0.14.2:

```
[1] M. Dobrushina et al., "Conducting MRI trials in Alzheimer's
    patients: Challenges and Guidelines," medRxiv, 2025, doi:
    10.1101/2025.07.02.25330723.
[2] T. Wilde, C. Rössl, and H. Theisel, ...
[3] K. Duwe et al., ...
```

(no backrefs anywhere — silent failure)

## Approach

Replace per-entry detection with a `show text:` rule that matches the literal `[N]` label prefix numbered styles (IEEE, GB-7714, etc.) emit at the start of each entry. When `[N]` is seen for N ≥ 2, prepend the backref for entry N-1 (which sits immediately before the label in the document flow). After the bibliography element finishes rendering, append the backref for the last entry — it has no following `[N+1]` to anchor on.

After this fix, the same `tests/ieee.typ` produces:

```
[1] M. Dobrushina et al., ...
(1, 2)[2] T. Wilde, ...
(1)[3] K. Duwe et al., ...
(2)
```

Backrefs all present. The visual placement is at the start of `[N+1]`'s line rather than at the end of `[N]`'s last line — a typst 0.14 layout consequence (no per-entry hook is exposed to user show-rules), but the data is correct and the link target is right.

## Why the legacy `show block:` path was removed

In typst 0.14 it fires on the whole bibliography block (since per-entry blocks no longer exist). Any document that pairs retrofit with another `show par:` or `show block:` hack — e.g. a CVPR-style first-line-indent-after-heading suppressor — gets caught in a recursion loop:

1. retrofit's `show block:` fires on the bibliography block, emits a modified block whose body contains paragraphs
2. the user's `show par:` hack fires on a paragraph, wraps it in a new block
3. retrofit's `show block:` fires on that new block
4. ... `maximum show rule depth exceeded`

I hit this on a real CVPR template port; reduces to a 30-line repro. Removing the dead path makes retrofit safe to combine with such hacks.

## Author-year styles

APA, Chicago author-date, etc. don't emit `[N]` anchors — they have no boundary marker we can hook on typst 0.14. `tests/apa-fmt.typ` therefore renders without backrefs after this PR. This is a regression in coverage from 0.13, but on 0.14 retrofit produced no backrefs for APA either (the `show block:` path didn't fire). Adding APA support on 0.14 needs a different detector and feels like a separate piece of work.

## Tests

Existing `tests/ieee.typ` now produces backrefs (verified). The `tests/apa-fmt.typ` is unchanged and silently produces no backrefs (same as 0.1.2 on typst 0.14).